### PR TITLE
remove sets

### DIFF
--- a/vite-frontend/src/components/UserWorkoutDetail.jsx
+++ b/vite-frontend/src/components/UserWorkoutDetail.jsx
@@ -48,7 +48,8 @@ const UserWorkoutDetail = () => {
   const completeWorkout = async () => {
     try {
       const workoutDocRef = doc(db, 'users', userId, 'workouts', workoutId);
-      await updateDoc(workoutDocRef, { completed: true, notes });
+      const completedAt = new Date().toISOString();
+      await updateDoc(workoutDocRef, { completed: true, notes, completedAt: completedAt });
       await saveWorkout();
       alert('Workout completed successfully!');
     } catch (error) {
@@ -196,7 +197,7 @@ const UserWorkoutDetail = () => {
             {(workout.exercises || []).map((exercise, exerciseIndex) => (
               <React.Fragment key={exerciseIndex}>
                 <tr>
-                  <td colSpan="5" style={{ border: '1px solid black', padding: '8px', textAlign: 'center', fontWeight: 'bold' }}>
+                  <td colSpan="4" style={{ border: '1px solid black', padding: '8px', textAlign: 'center', fontWeight: 'bold' }}>
                     {exercise.name}
                     {exercise.videoURL != null && exercise.videoURL.trim() !== '' && (
                       <a
@@ -214,7 +215,6 @@ const UserWorkoutDetail = () => {
                   <th style={{ border: '1px solid black', padding: '8px' }}>Set</th>
                   <th style={{ border: '1px solid black', padding: '8px' }}>Reps</th>
                   <th style={{ border: '1px solid black', padding: '8px' }}>Load</th>
-                  <th style={{ border: '1px solid black', padding: '8px' }}>Sets</th>
                   <th style={{ border: '1px solid black', padding: '4px' }}></th>
                 </tr>
                 {exercise.sets.map((set, setIndex) => (
@@ -237,14 +237,6 @@ const UserWorkoutDetail = () => {
                           style={{ width: '50px' }}
                         />
                       </td>
-                      <td style={{ border: '1px solid black', padding: '8px' }}>
-                        <input
-                          type="number"
-                          value={set.sets || ''}
-                          onChange={(e) => handleInputChange(exerciseIndex, setIndex, 'sets', e.target.value)}
-                          style={{ width: '50px' }}
-                        />
-                      </td>
                       <td style={{ border: '1px solid black', padding: '4px', textAlign: 'center', width: '25px' }}>
                         <span
                           onClick={() => handleInputChange(exerciseIndex, setIndex, 'completed',!set.completed)}
@@ -259,7 +251,7 @@ const UserWorkoutDetail = () => {
                     </tr>
                     {setIndex === exercise.sets.length - 1 && (
                       <tr>
-                        <td colSpan="5" style={{ border: '1px solid black', padding: '8px' }}>
+                        <td colSpan="4" style={{ border: '1px solid black', padding: '8px' }}>
                           <label>Notes:</label>
                           <textarea
                             value={notes[exerciseIndex] || ''}


### PR DESCRIPTION
This pull request includes several changes to the `UserWorkoutDetail` component in the `vite-frontend/src/components/UserWorkoutDetail.jsx` file. The main updates involve adding a timestamp when a workout is completed, and simplifying the exercise table by removing the "Sets" column and related input fields.

Changes to workout completion:

* Added a `completedAt` timestamp when updating a workout to indicate when it was completed.

Changes to exercise table:

* Removed the "Sets" column header from the exercise table.
* Removed the "Sets" input field for each exercise set.
* Adjusted column spans in the exercise table to account for the removed "Sets" column. [[1]](diffhunk://#diff-12a977f45dfe4a7ca7a1a88e088a5603740e88434b22297f0ae51def35b732e8L199-R200) [[2]](diffhunk://#diff-12a977f45dfe4a7ca7a1a88e088a5603740e88434b22297f0ae51def35b732e8L262-R254)