### PR TITLE
refactors template exercise row - exercise table already bussin'

### DIFF
--- a/vite-frontend/src/components/TemplateExerciseRow.tsx
+++ b/vite-frontend/src/components/TemplateExerciseRow.tsx
@@ -1,0 +1,91 @@
+import React, { ChangeEvent } from 'react';
+import { ExerciseInstance, Set } from '../types/workout';
+import ExerciseAutoComplete from './ExerciseAutoComplete';
+
+interface TemplateExerciseRowProps {
+  exercise: ExerciseInstance;
+  index: number;
+  onExerciseChange: (index: number, field: keyof ExerciseInstance, value: string) => void;
+  updateSet: (exerciseIndex: number, setIndex: number, field: keyof Set, value: number) => void;
+  addSet: (exerciseIndex: number) => void;
+  setExercises: React.Dispatch<React.SetStateAction<ExerciseInstance[]>>;
+}
+
+const TemplateExerciseRow: React.FC<TemplateExerciseRowProps> = ({
+  exercise,
+  index,
+  onExerciseChange,
+  updateSet,
+  addSet,
+  setExercises,
+}) => {
+  return (
+    <div style={{ marginBottom: '20px' }}>
+      <table style={{ borderCollapse: 'collapse', width: '100%', marginTop: '10px' }}>
+        <tbody>
+          <tr>
+            <td colSpan={3} style={{ border: '1px solid black', padding: '8px', backgroundColor: '#f5f5f5' }}>
+              <ExerciseAutoComplete
+                exercise={exercise}
+                index={index}
+                onExerciseChange={onExerciseChange}
+              />
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={3} style={{ border: '1px solid black', padding: '8px' }}>
+              <label>Coach Notes for Exercise: </label>
+              <textarea
+                value={exercise.coachNotes || ''}
+                onChange={(e) => {
+                  const updated = (prev: ExerciseInstance[]) => {
+                    const newExercises = [...prev];
+                    newExercises[index] = { ...newExercises[index], coachNotes: e.target.value };
+                    return newExercises;
+                  };
+                  setExercises(updated);
+                }}
+                style={{ width: '100%', marginTop: '5px' }}
+              />
+            </td>
+          </tr>
+          <tr>
+            <th style={{ border: '1px solid black', padding: '8px' }}>Set</th>
+            <th style={{ border: '1px solid black', padding: '8px' }}>Reps</th>
+            <th style={{ border: '1px solid black', padding: '8px' }}>Load</th>
+          </tr>
+          {exercise.sets.map((set, j) => (
+            <tr key={j}>
+              <td style={{ border: '1px solid black', padding: '8px', textAlign: 'center' }}>
+                {set.setNumber}
+              </td>
+              <td style={{ border: '1px solid black', padding: '8px' }}>
+                <input
+                  type="number"
+                  value={set.reps || ''}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => updateSet(index, j, 'reps', Number(e.target.value))}
+                  style={{ width: '50px' }}
+                />
+              </td>
+              <td style={{ border: '1px solid black', padding: '8px' }}>
+                <input
+                  type="number"
+                  value={set.load || ''}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => updateSet(index, j, 'load', Number(e.target.value))}
+                  style={{ width: '50px' }}
+                />
+              </td>
+            </tr>
+          ))}
+          <tr>
+            <td colSpan={3} style={{ border: '1px solid black', padding: '8px', textAlign: 'center' }}>
+              <button onClick={() => addSet(index)}>Add Set</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default TemplateExerciseRow;

--- a/vite-frontend/src/components/WorkoutTemplateBuilder.tsx
+++ b/vite-frontend/src/components/WorkoutTemplateBuilder.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, ChangeEvent } from 'react';
 import { collection, addDoc, getDocs, doc, getDoc, updateDoc, deleteDoc, setDoc } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 import ExerciseList from './ExerciseList';
-import ExerciseAutoComplete from './ExerciseAutoComplete';
+import TemplateExerciseRow from './TemplateExerciseRow';
 import { Link } from 'react-router-dom';
 import './WorkoutTemplateBuilder.css';
 import { Set, ExerciseDefinition, Workout, ExerciseInstance } from '../types/workout';
@@ -218,68 +218,15 @@ const WorkoutTemplateBuilder: React.FC = () => {
         <textarea value={coachNotes} onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setCoachNotes(e.target.value)} style={{ width: '95%' }} />
       </div>
       {exercises.map((exercise, i) => (
-        <div key={i} style={{ marginBottom: '20px' }}>
-          <table style={{ borderCollapse: 'collapse', width: '100%', marginTop: '10px' }}>
-            <tbody>
-              <tr>
-                <td colSpan={3} style={{ border: '1px solid black', padding: '8px', backgroundColor: '#f5f5f5' }}>
-                  <ExerciseAutoComplete
-                    exercise={exercise}
-                    index={i}
-                    onExerciseChange={onExerciseChange}
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td colSpan={3} style={{ border: '1px solid black', padding: '8px' }}>
-                  <label>Coach Notes for Exercise: </label>
-                  <textarea
-                    value={exercise.coachNotes || ''}
-                    onChange={(e) => {
-                      const updated = [...exercises];
-                      updated[i] = { ...updated[i], coachNotes: e.target.value };
-                      setExercises(updated);
-                    }}
-                    style={{ width: '100%', marginTop: '5px' }}
-                  />
-                </td>
-              </tr>
-              <tr>
-                <th style={{ border: '1px solid black', padding: '8px' }}>Set</th>
-                <th style={{ border: '1px solid black', padding: '8px' }}>Reps</th>
-                <th style={{ border: '1px solid black', padding: '8px' }}>Load</th>
-              </tr>
-              {exercise.sets.map((set, j) => (
-                <tr key={j}>
-                  <td style={{ border: '1px solid black', padding: '8px', textAlign: 'center' }}>
-                    {set.setNumber}
-                  </td>
-                  <td style={{ border: '1px solid black', padding: '8px' }}>
-                    <input
-                      type="number"
-                      value={set.reps || ''}
-                      onChange={(e: ChangeEvent<HTMLInputElement>) => updateSet(i, j, 'reps', Number(e.target.value))}
-                      style={{ width: '50px' }}
-                    />
-                  </td>
-                  <td style={{ border: '1px solid black', padding: '8px' }}>
-                    <input
-                      type="number"
-                      value={set.load || ''}
-                      onChange={(e: ChangeEvent<HTMLInputElement>) => updateSet(i, j, 'load', Number(e.target.value))}
-                      style={{ width: '50px' }}
-                    />
-                  </td>
-                </tr>
-              ))}
-              <tr>
-                <td colSpan={3} style={{ border: '1px solid black', padding: '8px', textAlign: 'center' }}>
-                  <button onClick={() => addSet(i)}>Add Set</button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <TemplateExerciseRow
+          key={i}
+          exercise={exercise}
+          index={i}
+          onExerciseChange={onExerciseChange}
+          updateSet={updateSet}
+          addSet={addSet}
+          setExercises={setExercises}
+        />
       ))}
       <div style={{ marginTop: '20px' }}>
         <button onClick={addExercise} style={{ marginRight: '10px' }}>Add Exercise</button>


### PR DESCRIPTION
This pull request introduces a new component `TemplateExerciseRow` and refactors the `WorkoutTemplateBuilder` to use this new component. The changes aim to modularize the code and improve maintainability.

Key changes include:

### New Component Addition:
* [`vite-frontend/src/components/TemplateExerciseRow.tsx`](diffhunk://#diff-f5a9f2a683536cf8d5a6e17e18b1d05801a04c5c4b1edb9e602845d689925160R1-R91): Created a new component `TemplateExerciseRow` to handle the display and interaction logic for individual exercise rows, including sets and coach notes.

### Refactoring:
* [`vite-frontend/src/components/WorkoutTemplateBuilder.tsx`](diffhunk://#diff-ff7bcc75daa56d9628d7ae0b4156fb07c71a95ec4460329dd1799075764655b0L221-L282): Replaced the inline exercise row logic with the new `TemplateExerciseRow` component, simplifying the `WorkoutTemplateBuilder` component.

### Import Adjustments:
* [`vite-frontend/src/components/WorkoutTemplateBuilder.tsx`](diffhunk://#diff-ff7bcc75daa56d9628d7ae0b4156fb07c71a95ec4460329dd1799075764655b0L5-R5): Updated imports to include `TemplateExerciseRow` and remove the now-unused `ExerciseAutoComplete`.