### PR TITLE
updates exerciseAutocomplete on change from firestore

### DIFF
--- a/vite-frontend/src/components/ExerciseAutoComplete.tsx
+++ b/vite-frontend/src/components/ExerciseAutoComplete.tsx
@@ -1,5 +1,5 @@
-import React, { useState, ChangeEvent } from 'react';
-import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
+import React, { useState, useEffect } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 import { ExerciseInstance } from '../types/workout';
 
@@ -30,16 +30,19 @@ const ExerciseAutoComplete: React.FC<ExerciseAutoCompleteProps> = ({ exercise, i
     }
   };
 
-  const fetchExerciseNames = async () => {
+  useEffect(() => {
     const exerciseCollection = collection(db, 'exercises');
-    const exerciseSnapshot = await getDocs(exerciseCollection);
-    const names = exerciseSnapshot.docs.map(doc => ({ id: doc.id, name: doc.data().name }));
-    setExerciseNames(names);
-    setFilteredNames(names);
-  };
-
-  useState(() => {
-    fetchExerciseNames();
+    const unsubscribe = onSnapshot(exerciseCollection, (snapshot) => {
+      const names = snapshot.docs.map(doc => ({ 
+        id: doc.id, 
+        name: doc.data().name 
+      }));
+      setExerciseNames(names);
+      setFilteredNames(names);
+    });
+    
+    // Clean up subscription on unmount
+    return () => unsubscribe();
   }, []);
 
   return (


### PR DESCRIPTION
This pull request includes changes to the `ExerciseAutoComplete` component in the `vite-frontend` project to improve the way exercise names are fetched and updated. The most important changes involve replacing the previous fetching method with a real-time subscription to Firestore.

Improvements to fetching exercise names:

* [`vite-frontend/src/components/ExerciseAutoComplete.tsx`](diffhunk://#diff-2c50a91a98f7768fab74de496bb154af2ee2c37c88f421e203e5c312cf5fd7e8L1-R2): Replaced `getDocs` with `onSnapshot` to subscribe to real-time updates from Firestore for exercise names. This ensures the component reflects the latest data without needing manual refreshes. [[1]](diffhunk://#diff-2c50a91a98f7768fab74de496bb154af2ee2c37c88f421e203e5c312cf5fd7e8L1-R2) [[2]](diffhunk://#diff-2c50a91a98f7768fab74de496bb154af2ee2c37c88f421e203e5c312cf5fd7e8L33-R45)

Code simplification and cleanup:

* [`vite-frontend/src/components/ExerciseAutoComplete.tsx`](diffhunk://#diff-2c50a91a98f7768fab74de496bb154af2ee2c37c88f421e203e5c312cf5fd7e8L33-R45): Removed the `fetchExerciseNames` function and integrated its logic within a `useEffect` hook. Added cleanup logic to unsubscribe from Firestore updates when the component unmounts.